### PR TITLE
Pass configuration parameters to ProductAPI

### DIFF
--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -86,11 +86,18 @@ abstract class AbstractApi{
 	 * @param string $endpoint top-level endpoint, e.g. `products`
 	 * @param string $mode 'production', 'sandbox'
 	 */
-	public function __construct( $endpoint, $mode = 'production' ) {
+	public function __construct( $endpoint, $mode = 'production', $config = false) {
 
 		$this->endpoint = $endpoint;
-
-		$this->merchantId = config('laravel-google-merchant-api.merchant_id', '');
+		
+		// Set config options / defaults
+		if ($config) {
+			$this->merchantId = $config['merchantId'];
+			$client_credentials_path = base_path( $config['credentials_path'] );
+		} else {
+			$this->merchantId = config('laravel-google-merchant-api.merchant_id', '');
+			$client_credentials_path = base_path( config('laravel-google-merchant-api.client_credentials_path') );
+		}
 
 		$version = config('laravel-google-merchant-api.version', 'v2');
 		if($mode === 'sandbox'){
@@ -107,8 +114,6 @@ abstract class AbstractApi{
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
         ]);
-
-		$client_credentials_path = base_path( config('laravel-google-merchant-api.client_credentials_path') );
 
 		if((strpos($client_credentials_path, '.json') !== false) && file_exists($client_credentials_path)){
 			$client = new \Google_Client();

--- a/src/Api/ProductApi.php
+++ b/src/Api/ProductApi.php
@@ -12,10 +12,9 @@ class ProductApi extends AbstractApi{
 	 * Setup the resource api
 	 *
 	 */
-	public function __construct() {
-
-		parent::__construct( 'products' );
-    }
+	public function __construct($mode='production', $config=false) {
+		parent::__construct( 'products', $mode, $config );
+    	}
 
     /**
      * Insert product(s).


### PR DESCRIPTION
Added configuration variable to ProductAPI object, allowing merchantID and Credentials Path to be passed into the object - defaulting to the config() defined options.

Requires a code change when implementing the ProductAPI object, as follows:

`use MOIREI\GoogleMerchantApi\Api\ProductApi;`

`$productApi = new ProductApi('production', $configArray);
  $productApi->sync()->insert($gmProduct);`