### PR TITLE
Allow pagination when retrieving products

### DIFF
--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -209,7 +209,7 @@ abstract class AbstractApi
 	{
 		if ('GET' === $this->request_method || 'DELETE' === $this->request_method) {
 			return [
-				'param' => json_encode($this->request_params)
+				'query' => $this->request_params
 			];
 		} else {
 			return [

--- a/src/Api/ProductApi.php
+++ b/src/Api/ProductApi.php
@@ -41,8 +41,8 @@ class ProductApi extends AbstractApi{
 	 * @throws \GuzzleHttp\Exception\ClientException
      * @throws MOIREI\GoogleMerchantApi\Exceptions\InvalidProductInput
      */
-    public function list(){
-        return $this->get();
+    public function list($pageToken = null, $maxResults = 25){
+        return $this->get(null, ['pageToken' => $pageToken, 'maxResults' => $maxResults]);
     }
 
     /**
@@ -65,6 +65,7 @@ class ProductApi extends AbstractApi{
         $instance->setRequestArgs( array(
 			'method' => 'GET',
 			'path'   => $id,
+            'params' => $params,
 		) );
 
 		$instance->clearCallbacks();


### PR DESCRIPTION
By default Google only serves 25 products per request.
This wrapper didn't allow passing the `nextPageToken` to retrieve more.